### PR TITLE
feat: Introducde Internal Helper Function_createTransaction In FactoryTokenContractV2

### DIFF
--- a/src/FactoryTokenContractV2.sol
+++ b/src/FactoryTokenContractV2.sol
@@ -535,6 +535,9 @@ contract FactoryTokenContractV2 is Ownable, ReentrancyGuard, Pausable {
         }
     }
 
+    /**
+     * @notice Create a new transaction
+     */
     function _createTransaction(
         address[] memory _signers,
         address _owner,

--- a/src/FactoryTokenContractV2.sol
+++ b/src/FactoryTokenContractV2.sol
@@ -534,4 +534,42 @@ contract FactoryTokenContractV2 is Ownable, ReentrancyGuard, Pausable {
             revert FactoryTokenContract__InvalidIPFSHash();
         }
     }
+
+    function _createTransaction(
+        address[] memory _signers,
+        address _owner,
+        string memory _tokenName,
+        string memory _tokenSymbol,
+        uint256 _totalSupply,
+        uint256 _maxSupply,
+        bool _canMint,
+        bool _canBurn,
+        bool _supplyCapEnabled,
+        string memory _ipfsHash
+    ) internal returns (uint256 txId) {
+        txId = nextTxId;
+        
+        transactions.push(TransactionData({
+            txId: txId,
+            owner: _owner,
+            signers: _signers,
+            isPending: true,
+            isExecuted: false,
+            tokenName: _tokenName,
+            tokenSymbol: _tokenSymbol,
+            totalSupply: _totalSupply,
+            maxSupply: _maxSupply,
+            canMint: _canMint,
+            canBurn: _canBurn,
+            supplyCapEnabled: _supplyCapEnabled,
+            tokenAddress: address(0),
+            ipfsHash: _ipfsHash,
+            createdAt: block.timestamp,
+            executedAt: 0,
+            liquidityProvided: 0
+        }));
+        
+        ownerToTxIds[_owner].push(txId);
+        nextTxId++;
+    }
 }


### PR DESCRIPTION
## Description
This PR introduces an internal helper function `_createTransaction` in `FactoryTokenContractV2`.  
It creates and stores a new transaction record with all relevant metadata (token details, permissions, ownership, and IPFS hash), preparing it for later execution.

## Changes Made
- Added `_createTransaction(...)` internal function  
- Implemented transaction struct creation with:  
  - Owner, signers, and token metadata (name, symbol, supply settings)  
  - Minting, burning, and supply cap flags  
  - IPFS hash for off-chain metadata  
  - Default states (`isPending`, `isExecuted`) and timestamps  
- Appended transaction to the `transactions` array  
- Updated `ownerToTxIds` mapping for owner-to-transaction tracking  
- Incremented `nextTxId` counter  
- Added NatSpec documentation  

## Type of Change
- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

## Testing
- [ ] Unit tests added for `_createTransaction`  
- [ ] Verified correct transaction struct creation  
- [ ] Confirmed `ownerToTxIds` mapping updates correctly  
- [ ] Checked increment behavior of `nextTxId`  
- [ ] Tested edge cases (empty signers, zero supply, invalid IPFS hash)  

## Checklist
- [x] My code follows the project's style guidelines  
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my feature works as intended  
- [x] New and existing tests pass locally with my changes  

## Related Issues
N/A  

## Security Considerations
- Transactions are initialized with `isPending = true` to ensure they cannot execute prematurely  
- IPFS hash allows off-chain validation without bloating on-chain storage  
- `nextTxId` ensures unique transaction identifiers, preventing collisions  

## Screenshots/Demo (if applicable)
N/A
