### PR TITLE
feat: Add Internal Function To Deploy A New Token Contract

### DIFF
--- a/src/FactoryTokenContractV2.sol
+++ b/src/FactoryTokenContractV2.sol
@@ -575,4 +575,17 @@ contract FactoryTokenContractV2 is Ownable, ReentrancyGuard, Pausable {
         ownerToTxIds[_owner].push(txId);
         nextTxId++;
     }
+
+    function _deployToken(TransactionData memory _txData) internal returns (TokenContract) {
+        return new TokenContract(
+            _txData.owner,
+            _txData.tokenName,
+            _txData.tokenSymbol,
+            _txData.totalSupply,
+            _txData.maxSupply,
+            _txData.canMint,
+            _txData.canBurn,
+            _txData.supplyCapEnabled
+        );
+    }
 }

--- a/src/FactoryTokenContractV2.sol
+++ b/src/FactoryTokenContractV2.sol
@@ -576,6 +576,9 @@ contract FactoryTokenContractV2 is Ownable, ReentrancyGuard, Pausable {
         nextTxId++;
     }
 
+    /**
+     * @notice Deploy a new token contract
+     */
     function _deployToken(TransactionData memory _txData) internal returns (TokenContract) {
         return new TokenContract(
             _txData.owner,


### PR DESCRIPTION
## Description
This PR adds an internal function `_deployToken` to `FactoryTokenContractV2`.  
It deploys a new `TokenContract` instance using the parameters stored in a `TransactionData` struct, enabling modular token creation within the factory flow.

## Changes Made
- Added `_deployToken(TransactionData memory _txData)` internal function  
- Implemented deployment logic for `TokenContract` with:  
  - Owner, token name, and symbol  
  - Initial supply and maximum supply  
  - Minting and burning permissions  
  - Supply cap enforcement flag  
- Added NatSpec documentation for maintainability and clarity  

## Type of Change
- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

## Testing
- [ ] Unit tests added for `_deployToken`  
- [ ] Verified successful deployment of a `TokenContract` with valid parameters  
- [ ] Checked proper initialization of token metadata (name, symbol, supply)  
- [ ] Confirmed mint/burn/supply cap flags are applied correctly  
- [ ] Tested edge cases (zero supply, supply cap disabled, invalid parameters)  

## Checklist
- [x] My code follows the project's style guidelines  
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my feature works as intended  
- [x] New and existing tests pass locally with my changes  

## Related Issues
N/A  

## Security Considerations
- Token deployment restricted to internal use, preventing unauthorized contract creation  
- Constructor parameters are sourced from validated `TransactionData` records  
- Ensures strong encapsulation of the token factory logic  

## Screenshots/Demo (if applicable)
N/A
