### PR TITLE
feat: Add Custom Errors to LiquidityManagerV2

### DIFF
--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -29,5 +29,6 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
     // Custom Errors //
     //////////////////
     error LiquidityManager__PoolAlreadyInitialized();
+    error LiquidityManager__PoolNotInitialized();
 
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -25,4 +25,7 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
     using SafeERC20 for IERC20;
     using CurrencyLibrary for Currency;
 
+    ////////////////////
+    // Custom Errors //
+    //////////////////
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -28,4 +28,6 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
     ////////////////////
     // Custom Errors //
     //////////////////
+    error LiquidityManager__PoolAlreadyInitialized();
+
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -30,5 +30,6 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
     //////////////////
     error LiquidityManager__PoolAlreadyInitialized();
     error LiquidityManager__PoolNotInitialized();
+    error LiquidityManager__InvalidTokenAddress();
 
 }


### PR DESCRIPTION
# PR Description
## Summary
This PR introduces **custom Solidity errors** to `LiquidityManagerV2.sol` for more gas-efficient and descriptive error handling.

## Changes
- Added **Natspec Header Section** for custom errors.
- Implemented the following errors:
  - `LiquidityManager__PoolAlreadyInitialized`
  - `LiquidityManager__PoolNotInitialized`
  - `LiquidityManager__InvalidTokenAddress`

## Motivation
Using **custom errors** instead of `require` with strings:
- Saves gas by avoiding long revert messages.
- Provides clearer error categorization.
- Improves maintainability and debugging in development.

## Notes
These custom errors will be integrated into core liquidity management logic in upcoming commits to replace generic `require` checks.
