### PR TITLE
feat: add external view functions for liquidity providers and user positions

### DIFF
--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -577,6 +577,12 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
             (pool.initialized, pool.totalLiquidity, pool.liquidityThreshold, pool.vestingDuration, pool.providersCount);
     }
 
+    /**
+     * @notice Get liquidity provider information
+     * @param poolId Pool identifier
+     * @param provider Provider address
+     * @return Liquidity provider data
+     */
         function getLiquidityProvider(bytes32 poolId, address provider) external view returns (LiquidityProvider memory) {
         return poolInfo[poolId].providers[provider];
     }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -587,6 +587,11 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         return poolInfo[poolId].providers[provider];
     }
 
+    /**
+     * @notice Get user positions
+     * @param user User address
+     * @return Array of liquidity positions
+     */
         function getUserPositions(address user) external view returns (LiquidityPosition[] memory) {
         return userPositions[user];
     }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -586,4 +586,8 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         function getLiquidityProvider(bytes32 poolId, address provider) external view returns (LiquidityProvider memory) {
         return poolInfo[poolId].providers[provider];
     }
+
+        function getUserPositions(address user) external view returns (LiquidityPosition[] memory) {
+        return userPositions[user];
+    }
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -583,7 +583,7 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
      * @param provider Provider address
      * @return Liquidity provider data
      */
-        function getLiquidityProvider(bytes32 poolId, address provider) external view returns (LiquidityProvider memory) {
+    function getLiquidityProvider(bytes32 poolId, address provider) external view returns (LiquidityProvider memory) {
         return poolInfo[poolId].providers[provider];
     }
 
@@ -592,7 +592,7 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
      * @param user User address
      * @return Array of liquidity positions
      */
-        function getUserPositions(address user) external view returns (LiquidityPosition[] memory) {
+    function getUserPositions(address user) external view returns (LiquidityPosition[] memory) {
         return userPositions[user];
     }
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -576,4 +576,8 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         return
             (pool.initialized, pool.totalLiquidity, pool.liquidityThreshold, pool.vestingDuration, pool.providersCount);
     }
+
+        function getLiquidityProvider(bytes32 poolId, address provider) external view returns (LiquidityProvider memory) {
+        return poolInfo[poolId].providers[provider];
+    }
 }


### PR DESCRIPTION
# Pull Request
## Summary
This PR enhances `LiquidityManagerV2` with new external view functions, allowing retrieval of liquidity provider details and user positions. These additions improve transparency and make it easier for frontends and integrators to query contract state.

## Changes
- **LiquidityManagerV2**
  - Added `getLiquidityProvider(poolId, provider)`:
    - Returns detailed `LiquidityProvider` data for a given pool and address.
    - Includes Natspec documentation.
  - Added `getUserPositions(user)`:
    - Returns an array of `LiquidityPosition` structs associated with a given user.
    - Includes Natspec documentation.
- Ran `forge fmt` to ensure consistent formatting.

## Motivation
- Enables external consumers (dApps, dashboards, indexers) to query pool participation and liquidity provider details directly on-chain.
- Lays groundwork for user-facing analytics and portfolio tracking.
- Provides read-only utility functions without affecting contract state.

## Next Steps
- Add pagination or filtering for large datasets (e.g., users with many positions).
- Extend view functions with additional metadata (e.g., reward eligibility, vesting progress).
- Integrate these functions into frontend dashboards.