### PR TITLE
feat: add admin functions for contract updates, pausing, and emergency mode

### DIFF
--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -678,6 +678,9 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
     // Internal Functions //
     ////////////////////
 
+    /**
+     * @notice Generate pool ID from token addresses and fee
+     */
         function _getPoolId(address token0, address token1, uint24 fee) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(token0, token1, fee));
     }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -666,6 +666,10 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         _unpause();
     }
 
+    /**
+     * @notice Enable emergency mode for a pool
+     * @param poolId Pool identifier
+     */
         function enableEmergencyMode(bytes32 poolId) external onlyOwner {
         poolInfo[poolId].emergencyMode = true;
     }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -641,6 +641,10 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         vestingContract = VestingContract(newVestingContract);
     }
 
+    /**
+     * @notice Update factory contract
+     * @param newFactory New factory contract address
+     */
     function updateFactoryContract(address newFactory) external onlyOwner {
         if (newFactory == address(0)) {
             revert LiquidityManager__InvalidTokenAddress();

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -673,4 +673,8 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
     function enableEmergencyMode(bytes32 poolId) external onlyOwner {
         poolInfo[poolId].emergencyMode = true;
     }
+
+    ////////////////////
+    // Internal Functions //
+    ////////////////////
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -681,18 +681,28 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
     /**
      * @notice Generate pool ID from token addresses and fee
      */
-        function _getPoolId(address token0, address token1, uint24 fee) internal pure returns (bytes32) {
+    function _getPoolId(address token0, address token1, uint24 fee) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(token0, token1, fee));
     }
 
     /**
      * @notice Validate pool initialization parameters
      */
-        function _validatePoolParameters(uint24 swapFee, uint256 liquidityThreshold, uint256 vestingDuration) internal pure {
-        if (swapFee != 100 && swapFee != 500 && swapFee != 3000 && swapFee != 10000) {
+    function _validatePoolParameters(
+        uint24 swapFee,
+        uint256 liquidityThreshold,
+        uint256 vestingDuration
+    )
+        internal
+        pure
+    {
+        if (swapFee != 100 && swapFee != 500 && swapFee != 3000 && swapFee != 10_000) {
             revert LiquidityManager__InvalidSwapFee();
         }
-        if (liquidityThreshold > 0 && (liquidityThreshold < MIN_LIQUIDITY_THRESHOLD || liquidityThreshold > MAX_LIQUIDITY_THRESHOLD)) {
+        if (
+            liquidityThreshold > 0
+                && (liquidityThreshold < MIN_LIQUIDITY_THRESHOLD || liquidityThreshold > MAX_LIQUIDITY_THRESHOLD)
+        ) {
             revert LiquidityManager__InsufficientLiquidity();
         }
         if (vestingDuration > 0 && (vestingDuration < MIN_VESTING_DURATION || vestingDuration > MAX_VESTING_DURATION)) {

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -665,4 +665,8 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
      */ function unpause() external onlyOwner {
         _unpause();
     }
+
+        function enableEmergencyMode(bytes32 poolId) external onlyOwner {
+        poolInfo[poolId].emergencyMode = true;
+    }
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -659,7 +659,10 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         _pause();
     }
 
-        function unpause() external onlyOwner {
+       
+           /**
+     * @notice Unpause the contract
+     */ function unpause() external onlyOwner {
         _unpause();
     }
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -651,4 +651,8 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         }
         factoryContract = newFactory;
     }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -640,4 +640,11 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         }
         vestingContract = VestingContract(newVestingContract);
     }
+
+    function updateFactoryContract(address newFactory) external onlyOwner {
+        if (newFactory == address(0)) {
+            revert LiquidityManager__InvalidTokenAddress();
+        }
+        factoryContract = newFactory;
+    }
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -659,10 +659,10 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         _pause();
     }
 
-       
-           /**
+    /**
      * @notice Unpause the contract
-     */ function unpause() external onlyOwner {
+     */
+    function unpause() external onlyOwner {
         _unpause();
     }
 
@@ -670,7 +670,7 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
      * @notice Enable emergency mode for a pool
      * @param poolId Pool identifier
      */
-        function enableEmergencyMode(bytes32 poolId) external onlyOwner {
+    function enableEmergencyMode(bytes32 poolId) external onlyOwner {
         poolInfo[poolId].emergencyMode = true;
     }
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -658,4 +658,8 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
     function pause() external onlyOwner {
         _pause();
     }
+
+        function unpause() external onlyOwner {
+        _unpause();
+    }
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -630,6 +630,10 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         protocolFeeRecipient = newRecipient;
     }
 
+    /**
+     * @notice Update vesting contract
+     * @param newVestingContract New vesting contract address
+     */
     function updateVestingContract(address newVestingContract) external onlyOwner {
         if (newVestingContract == address(0)) {
             revert LiquidityManager__InvalidTokenAddress();

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -652,6 +652,9 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         factoryContract = newFactory;
     }
 
+    /**
+     * @notice Pause the contract
+     */
     function pause() external onlyOwner {
         _pause();
     }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -685,6 +685,9 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         return keccak256(abi.encodePacked(token0, token1, fee));
     }
 
+    /**
+     * @notice Validate pool initialization parameters
+     */
         function _validatePoolParameters(uint24 swapFee, uint256 liquidityThreshold, uint256 vestingDuration) internal pure {
         if (swapFee != 100 && swapFee != 500 && swapFee != 3000 && swapFee != 10000) {
             revert LiquidityManager__InvalidSwapFee();

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -629,4 +629,11 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         }
         protocolFeeRecipient = newRecipient;
     }
+
+    function updateVestingContract(address newVestingContract) external onlyOwner {
+        if (newVestingContract == address(0)) {
+            revert LiquidityManager__InvalidTokenAddress();
+        }
+        vestingContract = VestingContract(newVestingContract);
+    }
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -677,4 +677,8 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
     ////////////////////
     // Internal Functions //
     ////////////////////
+
+        function _getPoolId(address token0, address token1, uint24 fee) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(token0, token1, fee));
+    }
 }

--- a/src/LiquidityManagerV2.sol
+++ b/src/LiquidityManagerV2.sol
@@ -684,4 +684,16 @@ contract LiquidityManagerV2 is Ownable, ReentrancyGuard, Pausable {
         function _getPoolId(address token0, address token1, uint24 fee) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(token0, token1, fee));
     }
+
+        function _validatePoolParameters(uint24 swapFee, uint256 liquidityThreshold, uint256 vestingDuration) internal pure {
+        if (swapFee != 100 && swapFee != 500 && swapFee != 3000 && swapFee != 10000) {
+            revert LiquidityManager__InvalidSwapFee();
+        }
+        if (liquidityThreshold > 0 && (liquidityThreshold < MIN_LIQUIDITY_THRESHOLD || liquidityThreshold > MAX_LIQUIDITY_THRESHOLD)) {
+            revert LiquidityManager__InsufficientLiquidity();
+        }
+        if (vestingDuration > 0 && (vestingDuration < MIN_VESTING_DURATION || vestingDuration > MAX_VESTING_DURATION)) {
+            revert LiquidityManager__InvalidAmount();
+        }
+    }
 }


### PR DESCRIPTION
# Pull Request
## Summary
This PR enhances the `LiquidityManagerV2` contract with additional **administrative controls**. These functions give the owner the ability to update critical contracts, pause/unpause protocol operations, and enable emergency mode for pools when necessary.

## Changes
- **LiquidityManagerV2**
  - Added `updateVestingContract(newVestingContract)`:
    - Updates the vesting contract reference.
    - Includes zero address validation.
  - Added `updateFactoryContract(newFactory)`:
    - Updates the factory contract reference.
    - Includes zero address validation.
  - Added `pause()`:
    - Pauses contract operations using OpenZeppelin’s `Pausable`.
  - Added `unpause()`:
    - Resumes contract operations.
  - Added `enableEmergencyMode(poolId)`:
    - Enables emergency mode for a given pool.
- Added full Natspec comments for all new functions.
- Ran `forge fmt` for consistent formatting.

## Motivation
- Provides flexibility to upgrade critical external contracts (vesting/factory).
- Improves protocol safety with the ability to pause/unpause operations in case of emergencies.
- Introduces emergency mode at the pool level for granular response to crises.
- Strengthens overall governance and operational resilience.

## Next Steps
- Emit dedicated events for each admin action to improve transparency.
- Introduce role-based access (e.g., `AccessControl`) instead of `onlyOwner` for better governance distribution.
- Consider timelock or multisig for critical admin operations to reduce centralization risks.
