### PR TITLE
feat: Introduce Custom Errors for MultiSigContractV2

### DIFF
--- a/src/MultiSigContractV2.sol
+++ b/src/MultiSigContractV2.sol
@@ -20,4 +20,7 @@ contract MultiSigContractV2 is Ownable, ReentrancyGuard, Pausable {
     ////////////////////
     // Custom Errors //
     //////////////////
+
+        error MultiSigContract__OnlyFactoryTokenContract();
+
 }

--- a/src/MultiSigContractV2.sol
+++ b/src/MultiSigContractV2.sol
@@ -22,5 +22,6 @@ contract MultiSigContractV2 is Ownable, ReentrancyGuard, Pausable {
     //////////////////
 
         error MultiSigContract__OnlyFactoryTokenContract();
+    error MultiSigContract__OnlySigner();
 
 }

--- a/src/MultiSigContractV2.sol
+++ b/src/MultiSigContractV2.sol
@@ -23,5 +23,7 @@ contract MultiSigContractV2 is Ownable, ReentrancyGuard, Pausable {
 
         error MultiSigContract__OnlyFactoryTokenContract();
     error MultiSigContract__OnlySigner();
+        error MultiSigContract__AlreadySigned();
+
 
 }

--- a/src/MultiSigContractV2.sol
+++ b/src/MultiSigContractV2.sol
@@ -16,4 +16,8 @@ import { DataLocation } from "@signprotocol/signprotocol-evm/src/models/DataLoca
  * @notice Enhanced multisig contract with comprehensive security features and governance
  * @dev Includes timelock, emergency functions, role management, and advanced attestation features
  */
-contract MultiSigContractV2 is Ownable, ReentrancyGuard, Pausable { }
+contract MultiSigContractV2 is Ownable, ReentrancyGuard, Pausable { 
+    ////////////////////
+    // Custom Errors //
+    //////////////////
+}

--- a/src/MultiSigContractV2.sol
+++ b/src/MultiSigContractV2.sol
@@ -16,14 +16,12 @@ import { DataLocation } from "@signprotocol/signprotocol-evm/src/models/DataLoca
  * @notice Enhanced multisig contract with comprehensive security features and governance
  * @dev Includes timelock, emergency functions, role management, and advanced attestation features
  */
-contract MultiSigContractV2 is Ownable, ReentrancyGuard, Pausable { 
+contract MultiSigContractV2 is Ownable, ReentrancyGuard, Pausable {
     ////////////////////
     // Custom Errors //
     //////////////////
 
-        error MultiSigContract__OnlyFactoryTokenContract();
+    error MultiSigContract__OnlyFactoryTokenContract();
     error MultiSigContract__OnlySigner();
-        error MultiSigContract__AlreadySigned();
-
-
+    error MultiSigContract__AlreadySigned();
 }


### PR DESCRIPTION
## Summary
This PR enhances the `MultiSigContractV2` contract with **custom error handling** and documentation improvements.  
By introducing explicit errors and a clear Natspec section header, we improve both the readability and runtime efficiency of the contract.

## Changes
- **Added Natspec section header** for `Custom Errors` in `MultiSigContractV2`.
- **Defined new custom errors**:
  - `MultiSigContract__OnlyFactoryTokenContract()`  
    ↳ Thrown when a restricted function is called by a non-factory token contract.
  - `MultiSigContract__OnlySigner()`  
    ↳ Thrown when a non-authorized signer attempts to act.
  - `MultiSigContract__AlreadySigned()`  
    ↳ Thrown when a signer attempts to sign an action more than once.
- Ran `forge fmt` to ensure consistent formatting.

## Motivation
- **Gas efficiency**: Custom errors are more efficient than `require` with revert strings.  
- **Clarity**: Explicitly named errors improve developer experience and make reverts easier to interpret.  
- **Maintainability**: Structured error management simplifies extending the contract with additional rules in the future.

## Next Steps
- Replace existing `require` statements with the new custom errors.
- Extend testing to ensure each error is correctly triggered under invalid conditions.
- Add developer documentation covering error usage patterns.

---
✅ Improves contract robustness, readability, and developer tooling alignment.
